### PR TITLE
Return 503 when the health monitor returns an unhealthy status

### DIFF
--- a/health_monitor.gemspec
+++ b/health_monitor.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "rack"
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/health_monitor/middleware/health_monitor_middleware.rb
+++ b/lib/health_monitor/middleware/health_monitor_middleware.rb
@@ -1,3 +1,6 @@
+require 'rack'
+require 'json'
+
 class HealthMonitorMiddleware
 
   @@monitor = HealthMonitor.new(name: nil)

--- a/lib/health_monitor/middleware/health_monitor_middleware.rb
+++ b/lib/health_monitor/middleware/health_monitor_middleware.rb
@@ -12,28 +12,37 @@ class HealthMonitorMiddleware
   end
 
   def call(env)
-    if env["REQUEST_URI"] =~ /#{@uri}/
+    return @app.call(env) unless env["REQUEST_URI"] =~ /#{@uri}/
+    request = Rack::Request.new(env)
 
-      request = Rack::Request.new(env)
+    stime = Time.now
+    data = @@monitor.get_status(request.params)
+    data[:time] = (Time.now - stime)
 
-      stime = Time.now
-      data = @@monitor.get_status(request.params)
-      data[:time] = (Time.now - stime)
-
-      if env["REQUEST_URI"] =~ /pingdom/
-        status = (data[:status] == :up) ? "OK" : "FAILED"
-        xml_response = "<pingdom_http_custom_check><status>#{status}</status><response_time>#{data[:time].round(3)}</response_time></pingdom_http_custom_check>"
-        [200, { 'Content-Type' => 'application/xml' },  [ xml_response ]]
-      else
-        [200, { 'Content-Type' => 'application/json' }, [ data.to_json ]]
-      end
-    else
-      @app.call(env)
-    end
+    make_response(env, data)
   end
 
   def self.add(type, params, &block)
     @@monitor.send("add_#{type}", params, &block)
   end
 
+  private def response_code(data)
+    return 503 unless data[:status] == :up
+    200
+  end
+
+  private def xml_response(data)
+    status = (data[:status] == :up) ? 'OK' : 'FAILED'
+    '<pingdom_http_custom_check>' \
+    "<status>#{status}</status>" \
+    "<response_time>#{data[:time].round(3)}</response_time>" \
+    '</pingdom_http_custom_check>'
+  end
+
+  private def make_response(env, data)
+    if env['REQUEST_URI'] =~ /pingdom/
+      return [response_code(data), { 'Content-Type' => 'application/xml' }, [xml_response(data)]]
+    end
+    [response_code(data), { 'Content-Type' => 'application/json' }, [data.to_json]]
+  end
 end

--- a/spec/middleware/health_monitor_middleware_spec.rb
+++ b/spec/middleware/health_monitor_middleware_spec.rb
@@ -1,0 +1,92 @@
+RSpec.describe HealthMonitorMiddleware do
+  let(:rack_app) { ->(_env) { [200, {}, ['Hello from Rack']] } }
+
+  let(:middleware) do
+    described_class.new(rack_app, 'the_name')
+  end
+
+  describe '#call' do
+    shared_examples_for 'calls the rack app' do
+      it 'calls the underlying rack app' do
+        expect(rack_app).to receive(:call).with(env)
+        subject
+      end
+
+      it "returns the underlying rack app's response" do
+        expect(subject.last.first).to eq('Hello from Rack')
+      end
+    end
+
+    shared_examples_for 'returns a health monitor response' do
+      it 'does not call the underlying rack app' do
+        expect(rack_app).not_to receive(:call).with(env)
+        subject
+      end
+
+      context 'health status is down' do
+        let(:monitor_status) { :down }
+
+        it 'returns 200' do
+          expect(subject.first).to eq(200)
+        end
+      end
+
+      context 'health status is up' do
+        let(:monitor_status) { :up }
+
+        it 'returns 200' do
+          expect(subject.first).to eq(200)
+        end
+      end
+    end
+
+    shared_examples_for 'response content type' do |expected_content_type|
+      it "response content type is set to #{expected_content_type}" do
+        expect(subject[1]['Content-Type']).to eq(expected_content_type)
+      end
+    end
+
+    let(:env) do
+      {
+        'REQUEST_URI' => request_uri,
+        'rack.input' => StringIO.new
+      }
+    end
+
+    let(:monitor_status) { :up }
+    let(:monitor_data) do
+      {
+        status: monitor_status
+      }
+    end
+
+    subject { middleware.call(env) }
+
+    before do
+      allow(middleware.class.class_variable_get(:@@monitor))
+        .to receive(:get_status).and_return(monitor_data)
+    end
+
+    context 'request_uri is /' do
+      let(:request_uri) { '/' }
+      include_examples 'calls the rack app'
+    end
+
+    context 'request_uri is /v1/users/evil-bot' do
+      let(:request_uri) { '/v1/users/evil-bot' }
+      include_examples 'calls the rack app'
+    end
+
+    context 'request_uri is /health_monitor' do
+      let(:request_uri) { '/health_monitor' }
+      include_examples 'returns a health monitor response'
+      include_examples 'response content type', 'application/json'
+    end
+
+    context 'request_uri is /health_monitor_pingdom' do
+      let(:request_uri) { '/health_monitor_pingdom' }
+      include_examples 'returns a health monitor response'
+      include_examples 'response content type', 'application/xml'
+    end
+  end
+end

--- a/spec/middleware/health_monitor_middleware_spec.rb
+++ b/spec/middleware/health_monitor_middleware_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe HealthMonitorMiddleware do
       context 'health status is down' do
         let(:monitor_status) { :down }
 
-        it 'returns 200' do
-          expect(subject.first).to eq(200)
+        it 'returns 503' do
+          expect(subject.first).to eq(503)
         end
       end
 


### PR DESCRIPTION
Changes:
- Add a (not that fancy) spec for the health monitor middleware
- Return HTTP status 503 if the health monitor check returns DOWN
- Refactor the health monitor middleware a bit