### PR TITLE
Rename gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Usage
 
 Add the gem to your Gemfile
 
-    gem 'health_monitor'
+    gem 'rt_health_monitor', require: 'health_monitor'
 
 Add the middleware to your config.
 

--- a/lib/health_monitor/version.rb
+++ b/lib/health_monitor/version.rb
@@ -1,3 +1,3 @@
 class HealthMonitor
-  VERSION = "0.7.2"
+  VERSION = "0.8.0.pre.rc1"
 end

--- a/rt_health_monitor.gemspec
+++ b/rt_health_monitor.gemspec
@@ -3,10 +3,10 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "health_monitor/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "health_monitor"
+  spec.name          = "rt_health_monitor"
   spec.version       = HealthMonitor::VERSION
-  spec.authors       = ["Siliva Mitter", "Martin Fuehrlinger", "0xdco"]
-  spec.email         = ["simi@runtastic.com", "maf@runtastic.com", "wv@0xd.co"]
+  spec.authors       = ["Martin Fuehrlinger", "0xdco", "Georg Gadinger"]
+  spec.email         = ["maf@runtastic.com", "wv@0xd.co", "nilsding@nilsding.org"]
 
   spec.summary       = "Monitor your db and services health!"
   spec.description   = "Monitoring"


### PR DESCRIPTION
Q: Should I also rename the `lib/health_monitor*` files to `lib/rt_health_monitor*` in here?  Would make this a version 1.x release then (due to breaking change as the `require`s would be now different) 